### PR TITLE
adds a named pipe based route exchange support with a data plane

### DIFF
--- a/cmd/gobgpd/util_windows.go
+++ b/cmd/gobgpd/util_windows.go
@@ -58,6 +58,22 @@ func (l *builtinLogger) GetLevel() log.LogLevel {
 	return log.LogLevel(l.logger.GetLevel())
 }
 
+func (l *builtinLogger) Infof(msg string, fields log.Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Infof(msg, args...)
+}
+
+func (l *builtinLogger) Errorf(msg string, fields log.Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Errorf(msg, args...)
+}
+
+func (l *builtinLogger) Fatalf(msg string, fields log.Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Fatalf(msg, args...)
+}
+
+func (l *builtinLogger) Debugf(msg string, fields log.Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Debugf(msg, args...)
+}
+
 func addSyslogHook(_, _ string) error {
 	return errors.New("syslog is not supported on this OS")
 }

--- a/cmd/gobgpsfpmd/main.go
+++ b/cmd/gobgpsfpmd/main.go
@@ -1,0 +1,85 @@
+//go:build windows
+// +build windows
+
+//-----------------------------------------------------------------------------
+//  Copyright (c) 2018 Infiot Inc.
+//  All rights reserved.
+//-----------------------------------------------------------------------------
+package main
+
+import (
+	"io"
+	"net"
+	"os"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/jessevdk/go-flags"
+	"github.com/osrg/gobgp/v3/internal/pkg/simplefpm"
+	log "github.com/sirupsen/logrus"
+)
+
+func sfpmsHandleClient(c net.Conn) {
+	defer c.Close()
+	log.Printf("Client connected [%s]", c.RemoteAddr().Network())
+
+	buf := make([]byte, 65536)
+	for {
+		n, err := c.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("read error: %v\n", err)
+			}
+			break
+		}
+		str := string(buf[:n])
+		log.Printf("read %d bytes: %q\n", n, str)
+		hdr := &simplefpm.SfpmHeader{}
+		hdr.SfpmhParse(buf)
+		//mm, err := simplefpm.SfpmParseBody(buf[10:], hdr)
+		log.Printf("hdr cmd:%v, len:%d", hdr.SfpmhCommand, hdr.SfpmhLen)
+	}
+
+	log.Println("Client disconnected")
+}
+
+func sfpmsStartServer(pipePath string) {
+	cc := &winio.PipeConfig{
+		MessageMode:      true,
+		InputBufferSize:  65536,
+		OutputBufferSize: 65536,
+	}
+	l, err := winio.ListenPipe(pipePath, cc)
+	if err != nil {
+		log.Fatal("listen error:", err)
+	}
+	defer l.Close()
+	log.Printf("Server listening op pipe %v\n", pipePath)
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Fatal("accept error:", err)
+		}
+		go sfpmsHandleClient(conn)
+	}
+}
+
+func main() {
+
+	var opts struct {
+		SfpmsPipePath string `short:"p" long:"path" description:"specify the listen path"`
+	}
+
+	_, err := flags.Parse(&opts)
+	if err != nil {
+		log.Errorf("unable to parse flags, err %v", err)
+		os.Exit(1)
+	}
+
+	if len(opts.SfpmsPipePath) == 0 {
+		log.Fatalf("named pipe path cannot be empty, exiting")
+		os.Exit(1)
+	}
+
+	sfpmsStartServer(opts.SfpmsPipePath)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/osrg/gobgp/v3
 
 require (
 	github.com/BurntSushi/toml v1.0.0
+	github.com/Microsoft/go-winio v0.5.2
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/eapache/channels v1.1.0
@@ -47,5 +48,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+//replace github.com/osrg/gobgp => ../gobgp
+//replace github.com/osrg/gobgp/internal/pkg/simplefpm => ../gobgp/internal/pkg/simplefpm
 
 go 1.18

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
+github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -101,6 +103,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -160,6 +163,7 @@ golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/pkg/config/bgp_configs.go
+++ b/internal/pkg/config/bgp_configs.go
@@ -1175,6 +1175,13 @@ type ZebraConfig struct {
 	SoftwareName string `mapstructure:"software-name" json:"software-name,omitempty"`
 }
 
+type SimpleFpmConfig struct {
+	// original -> gobgp:enabled
+	SfcEnabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
+	// original -> gobgp:url
+	SfcUrl string `mapstructure:"url" json:"url,omitempty"`
+}
+
 func (lhs *ZebraConfig) Equal(rhs *ZebraConfig) bool {
 	if lhs == nil || rhs == nil {
 		return false

--- a/internal/pkg/config/serve.go
+++ b/internal/pkg/config/serve.go
@@ -15,6 +15,7 @@ type BgpConfigSet struct {
 	Vrfs              []Vrf              `mapstructure:"vrfs"`
 	MrtDump           []Mrt              `mapstructure:"mrt-dump"`
 	Zebra             Zebra              `mapstructure:"zebra"`
+	SfpmCfg           SimpleFpmConfig    `mapstructure:"sfpm"`
 	Collector         Collector          `mapstructure:"collector"`
 	DefinedSets       DefinedSets        `mapstructure:"defined-sets"`
 	PolicyDefinitions []PolicyDefinition `mapstructure:"policy-definitions"`

--- a/internal/pkg/simplefpm/simplefpm_iproute.go
+++ b/internal/pkg/simplefpm/simplefpm_iproute.go
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------------------------
+//  Copyright (c) 2018 Infiot Inc.
+//  All rights reserved.
+//-----------------------------------------------------------------------------
+
+//go:build windows
+// +build windows
+
+package simplefpm
+
+import "encoding/binary"
+
+func (srb *SfpmIPRouteBody) sfpmbDecodeFromBytes(msgBuf []byte) error {
+	// Don't expect a route from the forwarding plane; not implemented
+	return nil
+}
+
+// sfmpSerialize serialize an SfpmIPRouteBody to SfpmIPRouteWireFmt
+func (srb *SfpmIPRouteBody) sfpmbSerialize() ([]byte, error) {
+	var buf []byte
+	numNexthop := len(srb.SrbNexthops)
+
+	bufInitSize := 16 //fixed fields
+	buf = make([]byte, bufInitSize)
+
+	st := 0
+	len := 1
+	buf[st] = uint8(srb.SrbType)
+	st += len
+
+	len = 2
+	binary.BigEndian.PutUint16(buf[st:st+len], uint16(srb.SrbInstance))
+	st += len
+
+	len = 1
+	buf[st] = uint8(srb.Safi)
+	st += len
+
+	len = 4
+	binary.BigEndian.PutUint32(buf[st:st+len], uint32(srb.SrbMetric))
+	st += len
+
+	len = 4
+	binary.BigEndian.PutUint32(buf[st:st+len], uint32(srb.SrbMtu))
+	st += len
+
+	len = 2
+	binary.BigEndian.PutUint16(buf[st:st+len], uint16(numNexthop))
+	st += len
+
+	buf = append(buf, srb.SrbPrefix.SfpFamily)
+	buf = append(buf, srb.SrbPrefix.SfpPrefixLen)
+	byteLen := (int(srb.SrbPrefix.SfpPrefixLen) + 7) / 8
+	buf = append(buf, srb.SrbPrefix.SfpPrefix[:byteLen]...)
+	for _, nh := range srb.SrbNexthops {
+		buf = append(buf, nh.SnhGate.To4()...)
+	}
+	return buf, nil
+}
+
+func (sfpmc *SfpmClient) SfpmSendIPRoute(vrfID uint32,
+	body *SfpmIPRouteBody, isWithdraw bool) error {
+
+	cmd := SfpmRouteAdd
+	if isWithdraw {
+		cmd = SfpmRouteDel
+	}
+
+	sfpmc.SfpmSendCommand(cmd, vrfID, body)
+	return nil
+}

--- a/internal/pkg/simplefpm/simplefpm_network.go
+++ b/internal/pkg/simplefpm/simplefpm_network.go
@@ -1,0 +1,267 @@
+//-----------------------------------------------------------------------------
+//  Copyright (c) 2018 Infiot Inc.
+//  All rights reserved.
+//-----------------------------------------------------------------------------
+
+//go:build windows
+// +build windows
+
+package simplefpm
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/osrg/gobgp/v3/pkg/log"
+)
+
+func SfpmReadAll(conn net.Conn, length int) ([]byte, error) {
+	buf := make([]byte, length)
+	_, err := io.ReadFull(conn, buf)
+	return buf, err
+}
+
+func SfpmGetHeaderSize() int {
+	return 10
+}
+
+func SfpmParseBody(msgBuf []byte, hdr *SfpmHeader) (*SfpmMessage, error) {
+	m := &SfpmMessage{
+		SfpmmHdr: *hdr,
+	}
+	cmd := hdr.SfpmhCommand
+
+	switch cmd {
+	case SfpmRouteAdd:
+		m.SfpmmBody = &SfpmIPRouteBody{}
+	}
+
+	m.SfpmmBody.sfpmbDecodeFromBytes(msgBuf)
+	return m, nil
+}
+
+func (Sfpmh *SfpmHeader) SfpmhParse(hdrBuf []byte) {
+	Sfpmh.SfpmhLen = binary.BigEndian.Uint16(hdrBuf[0:2])
+	Sfpmh.SfpmchMarker = hdrBuf[2]
+	Sfpmh.SfpmhVersion = hdrBuf[3]
+	Sfpmh.SfpmhVrfID = binary.BigEndian.Uint32(hdrBuf[4:8])
+	Sfpmh.SfpmhCommand = SfpmcAPIType(binary.BigEndian.Uint16(hdrBuf[8:10]))
+}
+
+func (sfpmc *SfpmClient) SfpmReceive() chan *SfpmMessage {
+	return sfpmc.SfpmcIncoming
+}
+
+func (sfpmc *SfpmClient) SfpmcStartCh() chan bool {
+	return sfpmc.SfpmcStart
+}
+
+func (sfpmc *SfpmClient) SfpmReceiveOneMsg() (*SfpmMessage, error) {
+	hdrBuf, err := SfpmReadAll(sfpmc.SfpmcConn, SfpmGetHeaderSize())
+	if err != nil {
+		return nil, err
+	}
+
+	hdr := &SfpmHeader{}
+	hdr.SfpmhParse(hdrBuf)
+
+	msgBodySize := int(hdr.SfpmhLen) - SfpmGetHeaderSize()
+	msgBuf, err := SfpmReadAll(sfpmc.SfpmcConn, msgBodySize)
+	if err != nil {
+		sfpmc.SfpmcLogger.Error("Error reading from msg body of size %v type %d",
+			log.Fields{
+				"msgSize": msgBodySize,
+				"command": hdr.SfpmhCommand,
+			})
+		return nil, err
+	}
+
+	mm, err := SfpmParseBody(msgBuf, hdr)
+
+	return mm, err
+
+}
+
+func (sfpmc *SfpmClient) sfpmStartRxLoop(address string) {
+
+	for {
+		if m, err := sfpmc.SfpmReceiveOneMsg(); err != nil {
+			sfpmc.SfpmcLogger.Infof("disconnected", log.Fields{"module": "sfpmcrxloop"})
+			sfpmc.SfpmcLogger.Infof("exiting", log.Fields{"module": "sfpmrxloop"})
+			close(sfpmc.SfpmcIncoming)
+			close(sfpmc.SfpmcOutgoing)
+			sfpmc.SfpmcClose <- true
+			return
+		} else if m != nil {
+			sfpmc.SfpmcIncoming <- m
+		}
+	}
+}
+
+func sfpmSerializeHeader(mm *SfpmMessage, bodyLen uint16) []byte {
+	headerLen := 10
+	buf := make([]byte, headerLen)
+	binary.BigEndian.PutUint16(buf[0:2], uint16(10+bodyLen))
+	buf[2] = mm.SfpmmHdr.SfpmchMarker
+	buf[3] = mm.SfpmmHdr.SfpmhVersion
+	binary.BigEndian.PutUint32(buf[4:8], uint32(mm.SfpmmHdr.SfpmhVrfID))
+	binary.BigEndian.PutUint16(buf[8:10], uint16(mm.SfpmmHdr.SfpmhCommand))
+
+	return buf
+}
+
+func (sfpmc *SfpmClient) sfpmStartTxLoop(address string) {
+
+	for {
+		select {
+		case m, more := <-sfpmc.SfpmcOutgoing:
+			if more {
+				b1, err := m.SfpmmBody.sfpmbSerialize()
+				if err != nil {
+					sfpmc.SfpmcLogger.Errorf("unable to serialize cmd %v, body %v, err %v",
+						log.Fields{"module": "sfpmtxloop"},
+						m.SfpmmHdr.SfpmhCommand,
+						m.SfpmmBody,
+						err)
+				}
+				b2 := sfpmSerializeHeader(m, uint16(len(b1)))
+				b := append(b2, b1...)
+				sfpmc.SfpmcLogger.Infof("sending serialized cmd %v, body %v, data %v, err %v",
+					log.Fields{"module": "sfpmtxloop"},
+					m.SfpmmHdr.SfpmhCommand,
+					m.SfpmmBody,
+					b,
+					err)
+				n, err := sfpmc.SfpmcConn.Write(b)
+				if err != nil {
+					sfpmc.SfpmcLogger.Errorf("error sending serialized data, err %v",
+						log.Fields{"module": "sfpmtxloop"},
+						err)
+				} else {
+					sfpmc.SfpmcLogger.Infof("sent %v bytes of serialized data(len=%d)",
+						log.Fields{"module": "sfpmtxloop"},
+						n,
+						len(b))
+				}
+			} else {
+				sfpmc.SfpmcLogger.Infof("closing tx channel, exiting loop",
+					log.Fields{"module": "sfpmtxloop"})
+				return
+			}
+		}
+	}
+}
+
+func (sfpmc *SfpmClient) sfpmSend(m *SfpmMessage) {
+	defer func() {
+		if err := recover(); err != nil {
+			sfpmc.SfpmcLogger.Infof("recovered from %v",
+				log.Fields{
+					"Topic": "sfpmsend"},
+				err)
+		}
+	}()
+	sfpmc.SfpmcLogger.Infof("send command %v with header %v Body %v to fpm",
+		log.Fields{"Topic": "sfpmsend"},
+		m.SfpmmHdr.SfpmhCommand,
+		m.SfpmmHdr,
+		m.SfpmmBody)
+	sfpmc.SfpmcOutgoing <- m
+}
+
+func (sfpmc *SfpmClient) SfpmSendCommand(cmd SfpmcAPIType,
+	vrfID uint32, body SfpmBody) error {
+	mm := &SfpmMessage{
+		SfpmmHdr: SfpmHeader{
+			SfpmhLen:     uint16(SfpmGetHeaderSize()),
+			SfpmchMarker: 0,
+			SfpmhVersion: 0,
+			SfpmhVrfID:   vrfID,
+			SfpmhCommand: cmd,
+		},
+		SfpmmBody: body,
+	}
+
+	sfpmc.sfpmSend(mm)
+	return nil
+}
+
+func (sfpmc *SfpmClient) sfpmBlockingConnect(address string) {
+	timeout := time.Duration(5 * time.Second)
+	sfpmc.SfpmcLogger.Info("connecting to ",
+		log.Fields{"address": address})
+	for {
+		conn, err := winio.DialPipe(address, &timeout)
+		if err != nil {
+			sfpmc.SfpmcLogger.Errorf("Error connecting to server %v, err %v",
+				log.Fields{"module": "sfpmloop"},
+				address,
+				err)
+			time.Sleep(timeout)
+			continue
+		}
+
+		sfpmc.SfpmcConn = conn
+		break
+	}
+
+	sfpmc.SfpmcLogger.Infof("connected to %s",
+		log.Fields{"module": "sfpmloop"},
+		address)
+}
+
+func (sfpmc *SfpmClient) SfpmStartWatcher() {
+	for {
+		select {
+		case <-sfpmc.SfpmcClose:
+			sfpmc.SfpmcConn.Close()
+			sfpmc.SfpmcLogger.Infof("reconnecting to %s",
+				log.Fields{"module": "sfpmwatcher"},
+				sfpmc.SfpmcAddress)
+			sfpmc.sfpmBlockingConnect(sfpmc.SfpmcAddress)
+			sfpmc.SfpmResetState()
+			go sfpmc.sfpmStartRxLoop(sfpmc.SfpmcAddress)
+			go sfpmc.sfpmStartTxLoop(sfpmc.SfpmcAddress)
+			sfpmc.SfpmcLogger.Infof("signal route refresh to %s via channel %v",
+				log.Fields{"module": "sfpmwatcher"},
+				sfpmc.SfpmcAddress,
+				sfpmc.SfpmcStartCh())
+			sfpmc.SfpmcStartCh() <- true
+		}
+	}
+}
+
+func (sfpc *SfpmClient) SfpmResetState() {
+	sfpc.SfpmcOutgoing = make(chan *SfpmMessage)
+	sfpc.SfpmcIncoming = make(chan *SfpmMessage)
+}
+
+func SfpmNewClient(logger log.Logger, address string) (*SfpmClient, error) {
+	// conn, err := net.Dial(network, address)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	outgoing := make(chan *SfpmMessage)
+	incoming := make(chan *SfpmMessage)
+	start := make(chan bool)
+
+	c := &SfpmClient{
+		SfpmcConn:     nil,
+		SfpmcLogger:   logger,
+		SfpmcIncoming: incoming,
+		SfpmcOutgoing: outgoing,
+		SfpmcClose:    make(chan bool),
+		SfpmcAddress:  address,
+		SfpmcStart:    start,
+	}
+
+	c.sfpmBlockingConnect(address)
+	go c.SfpmStartWatcher()
+	go c.sfpmStartRxLoop(address)
+	go c.sfpmStartTxLoop(address)
+	return c, nil
+}

--- a/internal/pkg/simplefpm/simplefpm_types.go
+++ b/internal/pkg/simplefpm/simplefpm_types.go
@@ -1,0 +1,115 @@
+//-----------------------------------------------------------------------------
+//  Copyright (c) 2018 Infiot Inc.
+//  All rights reserved.
+//-----------------------------------------------------------------------------
+
+package simplefpm
+
+import (
+	"net"
+
+	"github.com/osrg/gobgp/v3/pkg/log"
+)
+
+// NamedPipeMsgID for all SFPM messages is 1
+const SfpmNamedPipeMsgID = uint16(1)
+
+type SfpmcAPIType uint16
+type SfpmRouteType uint8
+type SfpmFlag uint64
+type SfpmMessageFlag uint32
+type SfpmSafi uint8
+type SfpmNexthopType uint8
+
+const (
+	SfpmRouteSystem SfpmRouteType = iota //0
+	SfpmRouteBGP                  = 9
+)
+
+const (
+	SfpmInterfaceAdd SfpmcAPIType = iota
+	SfpmRouteAdd
+	SfpmRouteDel
+)
+
+type SfpmBody interface {
+	sfpmbDecodeFromBytes([]byte) error
+	sfpmbSerialize() ([]byte, error)
+}
+
+type SfpmMessage struct {
+	SfpmmHdr  SfpmHeader
+	SfpmmBody SfpmBody
+}
+
+type SfpmClient struct {
+	SfpmcConn     net.Conn
+	SfpmcLogger   log.Logger
+	SfpmcIncoming chan *SfpmMessage
+	SfpmcOutgoing chan *SfpmMessage
+	SfpmcStart    chan bool
+	SfpmcClose    chan bool
+	SfpmcAddress  string
+}
+
+const SfpmClientReadSize = 65536
+
+type SfpmHeader struct {
+	SfpmhLen     uint16
+	SfpmchMarker uint8
+	SfpmhVersion uint8
+	SfpmhVrfID   uint32
+	SfpmhCommand SfpmcAPIType
+}
+
+type SfpmPrefix struct {
+	SfpFamily    uint8
+	SfpPrefixLen uint8
+	SfpPrefix    net.IP
+}
+
+type SfpmNexthop struct {
+	SnhType  SfpmNexthopType
+	SnhVrfID uint32
+	Snhflags uint8
+	SnhGate  net.IP
+}
+
+type SfpmIPRouteBody struct {
+	SrbType           SfpmRouteType
+	SrbInstance       uint16
+	Safi              SfpmSafi
+	SrbPrefix         SfpmPrefix
+	SrbSrcPrefix      SfpmPrefix
+	SrbNexthops       []SfpmNexthop
+	SrbbackupNexthops []SfpmNexthop
+	SrbNhgid          uint32
+	SrbDistance       uint8
+	SrbMetric         uint32
+	SrbTag            uint32
+	SrbMtu            uint32
+	SrbTableID        uint32
+}
+
+// this is solely to describe the wire format of a IPRoute Message Body
+// on the wire
+type SfpmIPRouteWireFmt struct {
+	SwfType         SfpmRouteType
+	SwfInstance     uint16
+	SwfSafi         uint8
+	SwfMetric       uint32
+	SwfMtu          uint32
+	SwfNumNexthops  uint16
+	SwfPrefixFamily uint8
+	SwfPrefixLen    uint8
+	SwfPrefix       []byte //length depends on the prefix len
+	SwfNexthops     []byte //SwfNumNexthops entries
+}
+
+type SfpmHeaderWireFmt struct {
+	SwfMsgLen  uint16
+	SwfMarker  uint8
+	SwfVersion uint8
+	SwfVrfID   uint32
+	SwfCmd     uint16
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -250,6 +250,18 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 		}
 	}
 
+	bgpServer.Log().Info("simple fpm server",
+		log.Fields{"enable": newConfig.SfpmCfg})
+	if newConfig.SfpmCfg.SfcEnabled {
+		bgpServer.Log().Info("enabling simple fpm server ",
+			log.Fields{"address": newConfig.SfpmCfg.SfcUrl})
+		err := bgpServer.EnableSfpm(ctx, newConfig.SfpmCfg.SfcUrl)
+		if err != nil {
+			bgpServer.Log().Fatal("failed to set simple fpm config",
+				log.Fields{"Topic": "config", "Error": err})
+		}
+	}
+
 	if len(newConfig.Collector.Config.Url) > 0 {
 		bgpServer.Log().Fatal("collector feature is not supported",
 			log.Fields{"Topic": "config"})

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -40,6 +40,10 @@ type Logger interface {
 	Warn(msg string, fields Fields)
 	Info(msg string, fields Fields)
 	Debug(msg string, fields Fields)
+	Infof(msg string, fields Fields, args ...interface{})
+	Errorf(msg string, fields Fields, args ...interface{})
+	Fatalf(msg string, fields Fields, args ...interface{})
+	Debugf(msg string, fields Fields, args ...interface{})
 	SetLevel(level LogLevel)
 	GetLevel() LogLevel
 }
@@ -70,6 +74,22 @@ func (l *DefaultLogger) Info(msg string, fields Fields) {
 
 func (l *DefaultLogger) Debug(msg string, fields Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Debug(msg)
+}
+
+func (l *DefaultLogger) Infof(msg string, fields Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Infof(msg, args...)
+}
+
+func (l *DefaultLogger) Errorf(msg string, fields Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Errorf(msg, args...)
+}
+
+func (l *DefaultLogger) Fatalf(msg string, fields Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Fatalf(msg, args...)
+}
+
+func (l *DefaultLogger) Debugf(msg string, fields Fields, args ...interface{}) {
+	l.logger.WithFields(logrus.Fields(fields)).Debugf(msg, args...)
 }
 
 func (l *DefaultLogger) SetLevel(level LogLevel) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -171,6 +171,7 @@ type BgpServer struct {
 	shutdownWG   *sync.WaitGroup
 	watcherMap   map[watchEventType][]*watcher
 	zclient      *zebraClient
+	sfpmclient   *sfpmClientCtx
 	bmpManager   *bmpClientManager
 	mrtManager   *mrtManager
 	roaTable     *table.ROATable
@@ -1790,6 +1791,18 @@ func (s *BgpServer) EnableZebra(ctx context.Context, r *api.EnableZebraRequest) 
 		}
 		var err error
 		s.zclient, err = newZebraClient(s, r.Url, protos, uint8(r.Version), r.NexthopTriggerEnable, uint8(r.NexthopTriggerDelay), r.MplsLabelRangeSize, software)
+		return err
+	}, false)
+}
+
+func (s *BgpServer) EnableSfpm(ctx context.Context, url string) error {
+	return s.mgmtOperation(func() error {
+		if s.sfpmclient != nil {
+			return fmt.Errorf("already connected to simple fpm server")
+		}
+
+		var err error
+		s.sfpmclient, err = newSimpleFpmClient(s, url)
 		return err
 	}, false)
 }

--- a/pkg/server/simplefpm_client.go
+++ b/pkg/server/simplefpm_client.go
@@ -1,0 +1,136 @@
+//-----------------------------------------------------------------------------
+//  Copyright (c) 2018 Infiot Inc.
+//  All rights reserved.
+//-----------------------------------------------------------------------------
+
+package server
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/osrg/gobgp/v3/internal/pkg/simplefpm"
+	"github.com/osrg/gobgp/v3/internal/pkg/table"
+	"github.com/osrg/gobgp/v3/pkg/log"
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+)
+
+type sfpmClientCtx struct {
+	sccClient *simplefpm.SfpmClient
+	sccBgpSrv *BgpServer
+}
+
+func (scc *sfpmClientCtx) sccLoop() {
+	var ww *watcher
+	ww = scc.sccBgpSrv.watch([]watchOption{
+		watchBestPath(true),
+	}...)
+
+	scc.sccBgpSrv.logger.Infof("start channel %v",
+		log.Fields{"module": "sfpmclient"},
+		scc.sccClient.SfpmcStartCh())
+	for {
+		select {
+		case <-scc.sccClient.SfpmcStartCh():
+			if ww != nil {
+				scc.sccBgpSrv.logger.Infof("stopping running watcher",
+					log.Fields{"module": "sfpmclient"})
+				ww.Stop()
+			}
+			scc.sccBgpSrv.logger.Infof("starting new watcher",
+				log.Fields{"module": "sfpmclient"})
+			ww = scc.sccBgpSrv.watch([]watchOption{
+				watchBestPath(true),
+			}...)
+		case msg := <-scc.sccClient.SfpmReceive():
+			if msg == nil {
+				break
+			}
+			switch body := msg.SfpmmBody.(type) {
+			case *simplefpm.SfpmIPRouteBody:
+				scc.sccBgpSrv.logger.Info("SfpmClient: received from server",
+					log.Fields{
+						"from": "SfpmServer",
+						"body": body,
+					})
+			}
+		case ev := <-ww.Event():
+			switch msg := ev.(type) {
+			case *watchEventBestPath:
+				scc.sccBgpSrv.logger.Infof("best path update %v",
+					log.Fields{"module": "sfpmclient"},
+					msg)
+				if table.UseMultiplePaths.Enabled {
+					for _, paths := range msg.MultiPathList {
+						//FIXME also handle per VRF routes here
+						body, isWithdraw := NewSimpleFpmIPRouteBody(paths, 0)
+						scc.sccClient.SfpmSendIPRoute(0, body, isWithdraw)
+					}
+				} else {
+					for _, path := range msg.PathList {
+						//FIXME also handle per VRF routes here
+						body, isWithdraw := NewSimpleFpmIPRouteBody([]*table.Path{path}, 0)
+						scc.sccClient.SfpmSendIPRoute(0, body, isWithdraw)
+					}
+				}
+			}
+		}
+	}
+}
+
+func newSimpleFpmClient(s *BgpServer, url string) (*sfpmClientCtx, error) {
+	cli, _ := simplefpm.SfpmNewClient(s.logger, url)
+
+	ww := &sfpmClientCtx{
+		sccClient: cli,
+		sccBgpSrv: s,
+	}
+
+	go ww.sccLoop()
+
+	return ww, nil
+}
+
+func NewSimpleFpmIPRouteBody(dst []*table.Path,
+	vrfID uint32) (*simplefpm.SfpmIPRouteBody, bool) {
+
+	paths := filterOutExternalPath(dst)
+	if len(paths) == 0 {
+		return nil, false
+	}
+
+	var prefix net.IP
+	var nexthop simplefpm.SfpmNexthop
+	path := paths[0]
+	l := strings.SplitN(path.GetNlri().String(), "/", 2)
+
+	nexthops := make([]simplefpm.SfpmNexthop, 0, len(paths))
+	switch path.GetRouteFamily() {
+	case bgp.RF_IPv4_UC:
+		prefix = path.GetNlri().(*bgp.IPAddrPrefix).IPAddrPrefixDefault.Prefix.To4()
+	case bgp.RF_IPv4_VPN:
+		prefix = path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).IPAddrPrefixDefault.Prefix.To4()
+	case bgp.RF_IPv6_UC:
+		prefix = path.GetNlri().(*bgp.IPv6AddrPrefix).IPAddrPrefixDefault.Prefix.To16()
+	case bgp.RF_IPv6_VPN:
+		prefix = path.GetNlri().(*bgp.LabeledVPNIPv6AddrPrefix).IPAddrPrefixDefault.Prefix.To16()
+	default:
+		return nil, false
+	}
+
+	for _, p := range paths {
+		nexthop.SnhGate = p.GetNexthop()
+		nexthop.SnhVrfID = 0 //FIXME: use the actual VRF eventually
+		nexthops = append(nexthops, nexthop)
+	}
+
+	plen, _ := strconv.ParseUint(l[1], 10, 8)
+	return &simplefpm.SfpmIPRouteBody{
+		SrbType: simplefpm.SfpmRouteBGP,
+		SrbPrefix: simplefpm.SfpmPrefix{
+			SfpPrefix:    prefix,
+			SfpPrefixLen: uint8(plen),
+		},
+	}, path.IsWithdraw
+}


### PR DESCRIPTION
- largely modelled on the zebra client/server approach.
- reuses most of the messages; binary encoding mostly
- uses named pipes as a transport

internal/pkg/simplefpm
- implements a named pipe based client library with message serializing support
- supports reconnect and route refresh

pkg/server/simplefpm_client.go
- implements the client using the simplefpm package
- subscribes to best path notifications
- supports route refresh on reconnect